### PR TITLE
Add "ignored paths" for the proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,12 @@ The following table lists the supported annotations for Kubernetes `Deployments`
 
 #### Pod Annotations
 
+The following table lists the supported annotations for Kubernetes `Pods` and their default values.
+
 | Annotation | Description | Default |
 | ---------- | ----------- | ------- |
 | `osiris.dm.gg/enabled` | Enable the metrics collecting proxy sidecar container to be injected into this pod. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
+| `osiris.dm.gg/ignoredPaths` | The list of (url) paths that should be "ignored" by Osiris. Requests to such paths won't be "counted" by the proxy. Format: comma-separated string. | _no value_ |
 
 #### Service Annotations
 

--- a/example/hello-osiris.yaml
+++ b/example/hello-osiris.yaml
@@ -41,6 +41,7 @@ spec:
         app: hello-osiris
       annotations:
         osiris.dm.gg/enabled: "true"
+        osiris.dm.gg/ignoredPaths: "/first/path,/second-path"
     spec:
       containers:
       - name: hello-osiris

--- a/pkg/kubernetes/osiris.go
+++ b/pkg/kubernetes/osiris.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	IgnoredPathsAnnotationName         = "osiris.dm.gg/ignoredPaths"
 	osirisEnabledAnnotationName        = "osiris.dm.gg/enabled"
 	metricsCheckIntervalAnnotationName = "osiris.dm.gg/metricsCheckInterval"
 )

--- a/pkg/metrics/proxy/injector/pod_patch.go
+++ b/pkg/metrics/proxy/injector/pod_patch.go
@@ -128,6 +128,10 @@ func (i *injector) getPodPatchOperations(
 					Name:  "METRICS_AND_HEALTH_PORT",
 					Value: fmt.Sprintf("%d", metricsAndHealthPort),
 				},
+				{
+					Name:  "IGNORED_PATHS",
+					Value: pod.Annotations[kubernetes.IgnoredPathsAnnotationName],
+				},
 			},
 			Ports: []corev1.ContainerPort{
 				{

--- a/pkg/metrics/proxy/proxy/config.go
+++ b/pkg/metrics/proxy/proxy/config.go
@@ -18,12 +18,15 @@ var portMappingRegex = regexp.MustCompile(`^(?:\d+\:\d+,)*(?:\d+\:\d+)$`)
 type config struct {
 	PortMappings         string `envconfig:"PORT_MAPPINGS" required:"true"`
 	MetricsAndHealthPort int    `envconfig:"METRICS_AND_HEALTH_PORT" required:"true"` // nolint: lll
+	// comma-separated list of URL paths that won't be counted
+	IgnoredPaths string `envconfig:"IGNORED_PATHS"`
 }
 
 // Config represents configuration options for the Osiris Proxy
 type Config struct {
 	PortMappings         map[int]int
 	MetricsAndHealthPort int
+	IgnoredPaths         map[string]struct{}
 }
 
 // NewConfigWithDefaults returns a Config object with default values already
@@ -58,6 +61,14 @@ func GetConfigFromEnvironment() (Config, error) {
 	}
 
 	c.MetricsAndHealthPort = internalC.MetricsAndHealthPort
+
+	ignoredPaths := strings.Split(internalC.IgnoredPaths, ",")
+	if len(ignoredPaths) > 0 {
+		c.IgnoredPaths = make(map[string]struct{}, len(ignoredPaths))
+		for _, ignoredPath := range ignoredPaths {
+			c.IgnoredPaths[ignoredPath] = struct{}{}
+		}
+	}
 
 	return c, nil
 }

--- a/pkg/metrics/proxy/proxy/proxy.go
+++ b/pkg/metrics/proxy/proxy/proxy.go
@@ -24,6 +24,7 @@ type proxy struct {
 	requestCount         *uint64
 	singlePortProxies    []*singlePortProxy
 	healthzAndMetricsSvr *http.Server
+	ignoredPaths         map[string]struct{}
 }
 
 func NewProxy(cfg Config) (Proxy, error) {
@@ -37,10 +38,11 @@ func NewProxy(cfg Config) (Proxy, error) {
 			Addr:    fmt.Sprintf(":%d", cfg.MetricsAndHealthPort),
 			Handler: healthzAndMetricsMux,
 		},
+		ignoredPaths: cfg.IgnoredPaths,
 	}
 	for proxyPort, appPort := range cfg.PortMappings {
 		singlePortProxy, err :=
-			newSinglePortProxy(proxyPort, appPort, p.requestCount)
+			newSinglePortProxy(proxyPort, appPort, p.requestCount, p.ignoredPaths)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
backport https://github.com/deislabs/osiris/pull/38

Expose a new proxy config for a list of "ignored paths". Requests to such paths won't be counted by the proxy.

Our use-case is the `/metrics` path used to expose prometheus metrics, and which is keeping our pods up all the time.

This is configured by adding a pod's annotation `osiris.dm.gg/ignoredPaths`, as a comma-separated string value:

```
apiVersion: apps/v1
kind: Deployment
spec:
  template:
    metadata:
      annotations:
        osiris.dm.gg/ignoredPaths: "/first/path,/second-path"
    spec:
      containers:
        ...
```