### PR TITLE
Ensure updates to metricsCheckInterval are taken into account

### DIFF
--- a/pkg/deployments/zeroscaler/zeroscaler.go
+++ b/pkg/deployments/zeroscaler/zeroscaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -127,48 +128,25 @@ func (z *zeroscaler) ensureMetricsCollection(deployment *appsv1.Deployment) {
 	defer z.collectorsLock.Unlock()
 	key := getDeploymentKey(deployment)
 	selector := labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels)
+	metricsCheckInterval := z.getMetricsCheckInterval(deployment)
 	if collector, ok := z.collectors[key]; !ok ||
-		!reflect.DeepEqual(selector, collector.selector) {
+		shouldUpdateCollector(collector, selector, metricsCheckInterval) {
 		if ok {
 			collector.stop()
 		}
-		metricsCheckInterval, err := k8s.GetMetricsCheckInterval(
-			deployment.Annotations,
-		)
-		if err != nil {
-			glog.Warningf(
-				"There was an error getting custom metrics check interval value "+
-					"in deployment %s, falling back to the default value of %d "+
-					"seconds; error: %s",
-				deployment.Name,
-				z.cfg.MetricsCheckInterval,
-				err,
-			)
-			metricsCheckInterval = z.cfg.MetricsCheckInterval
-		}
-		if metricsCheckInterval <= 0 {
-			glog.Warningf(
-				"Invalid custom metrics check interval value %d in deployment %s,"+
-					" falling back to the default value of %d seconds",
-				metricsCheckInterval,
-				deployment.Name,
-				z.cfg.MetricsCheckInterval,
-			)
-			metricsCheckInterval = z.cfg.MetricsCheckInterval
-		}
 		glog.Infof(
 			"Using new metrics collector for deployment %s in namespace %s "+
-				"with metrics check interval of %d seconds",
+				"with metrics check interval of %s",
 			deployment.Name,
 			deployment.Namespace,
-			metricsCheckInterval,
+			metricsCheckInterval.String(),
 		)
 		collector := newMetricsCollector(
 			z.kubeClient,
 			deployment.Name,
 			deployment.Namespace,
 			selector,
-			time.Duration(metricsCheckInterval)*time.Second,
+			metricsCheckInterval,
 		)
 		go func() {
 			collector.run(z.ctx)
@@ -196,6 +174,55 @@ func (z *zeroscaler) ensureNoMetricsCollection(deployment *appsv1.Deployment) {
 		collector.stop()
 		delete(z.collectors, key)
 	}
+}
+
+func (z *zeroscaler) getMetricsCheckInterval(
+	deployment *appsv1.Deployment,
+) time.Duration {
+	var (
+		metricsCheckInterval int
+		err                  error
+	)
+	if rawMetricsCheckInterval, ok :=
+		deployment.Annotations[k8s.MetricsCheckIntervalAnnotationName]; ok {
+		metricsCheckInterval, err = strconv.Atoi(rawMetricsCheckInterval)
+		if err != nil {
+			glog.Warningf(
+				"There was an error getting custom metrics check interval value "+
+					"in deployment %s, falling back to the default value of %d "+
+					"seconds; error: %s",
+				deployment.Name,
+				z.cfg.MetricsCheckInterval,
+				err,
+			)
+			metricsCheckInterval = z.cfg.MetricsCheckInterval
+		}
+	}
+	if metricsCheckInterval <= 0 {
+		glog.Warningf(
+			"Invalid custom metrics check interval value %d in deployment %s,"+
+				" falling back to the default value of %d seconds",
+			metricsCheckInterval,
+			deployment.Name,
+			z.cfg.MetricsCheckInterval,
+		)
+		metricsCheckInterval = z.cfg.MetricsCheckInterval
+	}
+	return time.Duration(metricsCheckInterval) * time.Second
+}
+
+func shouldUpdateCollector(
+	collector *metricsCollector,
+	newSelector labels.Selector,
+	newMetricsCheckInterval time.Duration,
+) bool {
+	if !reflect.DeepEqual(newSelector, collector.selector) {
+		return true
+	}
+	if newMetricsCheckInterval != collector.metricsCheckInterval {
+		return true
+	}
+	return false
 }
 
 func getDeploymentKey(deployment *appsv1.Deployment) string {

--- a/pkg/deployments/zeroscaler/zeroscaler_test.go
+++ b/pkg/deployments/zeroscaler/zeroscaler_test.go
@@ -1,0 +1,156 @@
+package zeroscaler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	k8s "github.com/dailymotion/osiris/pkg/kubernetes"
+)
+
+func TestShouldUpdateCollector(t *testing.T) {
+	testcases := []struct {
+		name                    string
+		collector               *metricsCollector
+		newSelector             labels.Selector
+		newMetricsCheckInterval time.Duration
+		expectedResult          bool
+	}{
+		{
+			name: "same selector and metricsCheckInterval",
+			collector: &metricsCollector{
+				selector:             labels.Everything(),
+				metricsCheckInterval: 5 * time.Second,
+			},
+			newSelector:             labels.Everything(),
+			newMetricsCheckInterval: 5 * time.Second,
+			expectedResult:          false,
+		},
+		{
+			name: "same selector but different metricsCheckInterval",
+			collector: &metricsCollector{
+				selector:             labels.Everything(),
+				metricsCheckInterval: 5 * time.Second,
+			},
+			newSelector:             labels.Everything(),
+			newMetricsCheckInterval: 10 * time.Second,
+			expectedResult:          true,
+		},
+		{
+			name: "different selector but same metricsCheckInterval",
+			collector: &metricsCollector{
+				selector:             labels.Everything(),
+				metricsCheckInterval: 5 * time.Second,
+			},
+			newSelector:             labels.Nothing(),
+			newMetricsCheckInterval: 5 * time.Second,
+			expectedResult:          true,
+		},
+		{
+			name: "different selector and metricsCheckInterval",
+			collector: &metricsCollector{
+				selector:             labels.Everything(),
+				metricsCheckInterval: 5 * time.Second,
+			},
+			newSelector:             labels.Nothing(),
+			newMetricsCheckInterval: 10 * time.Second,
+			expectedResult:          true,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			actual := shouldUpdateCollector(
+				test.collector,
+				test.newSelector,
+				test.newMetricsCheckInterval,
+			)
+
+			assert.Equal(t, test.expectedResult, actual)
+		})
+	}
+}
+
+func TestGetMetricsCheckInterval(t *testing.T) {
+	testcases := []struct {
+		name           string
+		zeroScaler     *zeroscaler
+		deployment     *appsv1.Deployment
+		expectedResult time.Duration
+	}{
+		{
+			name: "no specific annotation",
+			zeroScaler: &zeroscaler{
+				cfg: Config{
+					MetricsCheckInterval: 150,
+				},
+			},
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expectedResult: 150 * time.Second,
+		},
+		{
+			name: "custom valid annotation",
+			zeroScaler: &zeroscaler{
+				cfg: Config{
+					MetricsCheckInterval: 150,
+				},
+			},
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						k8s.MetricsCheckIntervalAnnotationName: "60",
+					},
+				},
+			},
+			expectedResult: 60 * time.Second,
+		},
+		{
+			name: "custom invalid annotation value",
+			zeroScaler: &zeroscaler{
+				cfg: Config{
+					MetricsCheckInterval: 150,
+				},
+			},
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						k8s.MetricsCheckIntervalAnnotationName: "something",
+					},
+				},
+			},
+			expectedResult: 150 * time.Second,
+		},
+		{
+			name: "custom negative annotation value",
+			zeroScaler: &zeroscaler{
+				cfg: Config{
+					MetricsCheckInterval: 150,
+				},
+			},
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						k8s.MetricsCheckIntervalAnnotationName: "-60",
+					},
+				},
+			},
+			expectedResult: 150 * time.Second,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.zeroScaler.getMetricsCheckInterval(test.deployment)
+
+			assert.Equal(t, test.expectedResult, actual)
+		})
+	}
+}

--- a/pkg/kubernetes/osiris.go
+++ b/pkg/kubernetes/osiris.go
@@ -1,15 +1,14 @@
 package kubernetes
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 )
 
 const (
 	IgnoredPathsAnnotationName         = "osiris.dm.gg/ignoredPaths"
+	MetricsCheckIntervalAnnotationName = "osiris.deislabs.io/metricsCheckInterval"
 	osirisEnabledAnnotationName        = "osiris.dm.gg/enabled"
-	metricsCheckIntervalAnnotationName = "osiris.dm.gg/metricsCheckInterval"
 )
 
 // ResourceIsOsirisEnabled checks the annotations to see if the
@@ -40,28 +39,4 @@ func GetMinReplicas(annotations map[string]string, defaultVal int32) int32 {
 		return defaultVal
 	}
 	return int32(minReplicas)
-}
-
-// GetMetricsCheckInterval gets the interval in which the zeroScaler would
-// repeatedly track the pod http request metrics. The value is the number
-// of seconds of the interval. If it fails to do so, it returns an error.
-func GetMetricsCheckInterval(annotations map[string]string) (int, error) {
-	if len(annotations) == 0 {
-		return 0, nil
-	}
-	val, ok := annotations[metricsCheckIntervalAnnotationName]
-	if !ok {
-		return 0, nil
-	}
-	metricsCheckInterval, err := strconv.Atoi(val)
-	if err != nil {
-		return 0, fmt.Errorf("invalid int value '%s' for '%s' annotation: %s",
-			val, metricsCheckIntervalAnnotationName, err)
-	}
-	if metricsCheckInterval <= 0 {
-		return 0, fmt.Errorf("metricsCheckInterval should be positive, "+
-			"'%d' is not a valid value",
-			metricsCheckInterval)
-	}
-	return metricsCheckInterval, nil
 }

--- a/pkg/kubernetes/osiris_test.go
+++ b/pkg/kubernetes/osiris_test.go
@@ -2,9 +2,6 @@ package kubernetes
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResourceIsOsirisEnabled(t *testing.T) {
@@ -113,85 +110,6 @@ func TestGetMinReplicas(t *testing.T) {
 					"expected GetMinReplicas to return %d, but got %d",
 					test.expectedResult, actual)
 			}
-		})
-	}
-}
-
-func TestGetMetricsCheckInterval(t *testing.T) {
-	testcases := []struct {
-		name           string
-		annotations    map[string]string
-		expectedResult int
-		expectedError  string
-	}{
-		{
-			name:           "nil map",
-			annotations:    nil,
-			expectedResult: 0,
-			expectedError:  "",
-		},
-		{
-			name:           "empty map",
-			annotations:    map[string]string{},
-			expectedResult: 0,
-			expectedError:  "",
-		},
-		{
-			name: "map with no metrics check interval entry",
-			annotations: map[string]string{
-				"whatever": "60",
-			},
-			expectedResult: 0,
-			expectedError:  "",
-		},
-		{
-			name: "map with invalid metrics check interval entry",
-			annotations: map[string]string{
-				"osiris.dm.gg/metricsCheckInterval": "invalid",
-			},
-			expectedResult: 0,
-			expectedError: "invalid int value 'invalid' for " +
-				"'osiris.dm.gg/metricsCheckInterval' annotation: " +
-				"strconv.Atoi: parsing \"invalid\": invalid syntax",
-		},
-		{
-			name: "map with negative metrics check interval entry",
-			annotations: map[string]string{
-				"osiris.dm.gg/metricsCheckInterval": "-1",
-			},
-			expectedResult: 0,
-			expectedError: "metricsCheckInterval should be positive, " +
-				"'-1' is not a valid value",
-		},
-		{
-			name: "map with zero metrics check interval entry",
-			annotations: map[string]string{
-				"osiris.dm.gg/metricsCheckInterval": "0",
-			},
-			expectedResult: 0,
-			expectedError: "metricsCheckInterval should be positive, " +
-				"'0' is not a valid value",
-		},
-		{
-			name: "map with valid metrics check interval entry",
-			annotations: map[string]string{
-				"osiris.dm.gg/metricsCheckInterval": "60",
-			},
-			expectedResult: 60,
-			expectedError:  "",
-		},
-	}
-
-	for _, test := range testcases {
-		t.Run(test.name, func(t *testing.T) {
-			actual, err := GetMetricsCheckInterval(test.annotations)
-			if len(test.expectedError) > 0 {
-				require.EqualError(t, err, test.expectedError, "")
-			} else {
-				require.NoError(t, err)
-			}
-
-			assert.Equal(t, test.expectedResult, actual)
 		})
 	}
 }


### PR DESCRIPTION
backport https://github.com/deislabs/osiris/pull/52

The first implementation of the per-deployment metricsCheckInterval never took into account updates of the annotation value.
The new one read the annotation value and compare it to the current one to decide if the metrics collector should be recreated or not.