### PR TITLE
Add support for StatefulSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Various types of Kubernetes resources can be Osiris-enabled using an annotation.
 Osiris-enabled pods are automatically instrumented with a __metrics-collecting
 proxy__ deployed as a sidecar container.
 
-Osiris-enabled deployments (if _already_ scaled to a configurable minimum number
-of replicas-- one by default) automatically have metrics from their pods
-continuously scraped and analyzed by the __zeroscaler__ component. When the
-aggregated metrics reveal that all of the deployment's pods are idling, the
-zeroscaler scales the deployment to zero replicas.
+Osiris-enabled deployments or statefulSets (if _already_ scaled to a configurable
+minimum number of replicas-- one by default) automatically have metrics from
+their pods continuously scraped and analyzed by the __zeroscaler__ component.
+When the aggregated metrics reveal that all of the deployment's pods are idling,
+the zeroscaler scales the deployment to zero replicas.
 
 Under normal circumstances, scaling a deployment to zero replicas poses a
 problem: any services that select pods from that deployment (and only that
@@ -175,14 +175,14 @@ spec:
 
 Most of Osiris configuration is done with Kubernetes annotations - as seen in the Usage section.
 
-#### Deployment Annotations
+#### Deployment & StatefulSet Annotations
 
-The following table lists the supported annotations for Kubernetes `Deployments` and their default values.
+The following table lists the supported annotations for Kubernetes `Deployments` and `StatefulSets`, and their default values.
 
 | Annotation | Description | Default |
 | ---------- | ----------- | ------- |
-| `osiris.dm.gg/enabled` | Enable the zeroscaler component to scrape and analyze metrics from the deployment's pods and scale the deployment to zero when idle. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
-| `osiris.dm.gg/minReplicas` | The minimum number of replicas to set on the deployment when Osiris will scale up. If you set `2`, Osiris will scale the deployment from `0` to `2` replicas directly. Osiris won't collect metrics from deployments which have more than `minReplicas` replicas - to avoid useless collections of metrics. | `1` |
+| `osiris.dm.gg/enabled` | Enable the zeroscaler component to scrape and analyze metrics from the deployment's or statefulSet's pods and scale the deployment/statefulSet to zero when idle. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
+| `osiris.dm.gg/minReplicas` | The minimum number of replicas to set on the deployment/statefulSet when Osiris will scale up. If you set `2`, Osiris will scale the deployment/statefulSet from `0` to `2` replicas directly. Osiris won't collect metrics from deployments/statefulSets which have more than `minReplicas` replicas - to avoid useless collections of metrics. | `1` |
 | `osiris.dm.gg/metricsCheckInterval` | The interval in which Osiris would repeatedly track the pod http request metrics. The value is the number of seconds of the interval. Note that this value override the global value defined by the `zeroscaler.metricsCheckInterval` Helm value. | _value of the `zeroscaler.metricsCheckInterval` Helm value_ |
 
 #### Pod Annotations
@@ -202,6 +202,7 @@ The following table lists the supported annotations for Kubernetes `Services` an
 | ---------- | ----------- | ------- |
 | `osiris.dm.gg/enabled` | Enable this service's endpoints to be managed by the Osiris endpoints controller. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
 | `osiris.dm.gg/deployment` | Name of the deployment which is behind this service. This is _required_ to map the service with its deployment. | _no value_ |
+| `osiris.dm.gg/statefulset` | Name of the statefulSet which is behind this service. This is _required_ to map the service with its statefulSet. | _no value_ |
 | `osiris.dm.gg/loadBalancerHostname` | Map requests coming from a specific hostname to this service. Note that if you have multiple hostnames, you can set them with different annotations, using `osiris.dm.gg/loadBalancerHostname-1`, `osiris.dm.gg/loadBalancerHostname-2`, ... | _no value_ |
 | `osiris.dm.gg/ingressHostname` | Map requests coming from a specific hostname to this service. If you use an ingress in front of your service, this is required to create a link between the ingress and the service. Note that if you have multiple hostnames, you can set them with different annotations, using `osiris.dm.gg/ingressHostname-1`, `osiris.dm.gg/ingressHostname-2`, ... | _no value_ |
 | `osiris.dm.gg/ingressDefaultPort` | Custom service port when the request comes from an ingress. Default behaviour if there are more than 1 port on the service, is to look for a port named `http`, and fallback to the port `80`. Set this if you have multiple ports and using a non-standard port with a non-standard name. | _no value_ |

--- a/charts/osiris/templates/cluster-role.yaml
+++ b/charts/osiris/templates/cluster-role.yaml
@@ -32,6 +32,7 @@ rules:
   - apps
   resources:
   - deployments
+  - statefulsets
   verbs:
   - get
   - list

--- a/pkg/deployments/activator/activating.go
+++ b/pkg/deployments/activator/activating.go
@@ -15,24 +15,24 @@ import (
 func (a *activator) activateDeployment(
 	ctx context.Context,
 	app *app,
-) (*deploymentActivation, error) {
+) (*appActivation, error) {
 	deploymentsClient := a.kubeClient.AppsV1().Deployments(app.namespace)
 	deployment, err := deploymentsClient.Get(
 		ctx,
-		app.deploymentName,
+		app.name,
 		metav1.GetOptions{},
 	)
 	if err != nil {
 		return nil, err
 	}
-	da := &deploymentActivation{
+	da := &appActivation{
 		readyAppPodIPs: map[string]struct{}{},
 		successCh:      make(chan struct{}),
 		timeoutCh:      make(chan struct{}),
 	}
 	glog.Infof(
 		"Activating deployment %s in namespace %s",
-		app.deploymentName,
+		app.name,
 		app.namespace,
 	)
 	go da.watchForCompletion(
@@ -55,7 +55,58 @@ func (a *activator) activateDeployment(
 	patchesBytes, _ := json.Marshal(patches)
 	_, err = deploymentsClient.Patch(
 		ctx,
-		app.deploymentName,
+		app.name,
+		k8s_types.JSONPatchType,
+		patchesBytes,
+		metav1.PatchOptions{},
+	)
+	return da, err
+}
+
+func (a *activator) activateStatefulSet(
+	ctx context.Context,
+	app *app,
+) (*appActivation, error) {
+	statefulSetsClient := a.kubeClient.AppsV1().StatefulSets(app.namespace)
+	statefulSet, err := statefulSetsClient.Get(
+		ctx,
+		app.name,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	da := &appActivation{
+		readyAppPodIPs: map[string]struct{}{},
+		successCh:      make(chan struct{}),
+		timeoutCh:      make(chan struct{}),
+	}
+	glog.Infof(
+		"Activating statefulSet %s in namespace %s",
+		app.name,
+		app.namespace,
+	)
+	go da.watchForCompletion(
+		a.kubeClient,
+		app,
+		labels.Set(statefulSet.Spec.Selector.MatchLabels).AsSelector(),
+	)
+	if statefulSet.Spec.Replicas == nil || *statefulSet.Spec.Replicas > 0 {
+		// We don't need to do this, as it turns out! Scaling is either already
+		// in progress-- perhaps initiated by another process-- or may even be
+		// completed already. Just return dr and allow the caller to move on to
+		// verifying / waiting for this activation to be complete.
+		return da, nil
+	}
+	patches := []kubernetes.PatchOperation{{
+		Op:    "replace",
+		Path:  "/spec/replicas",
+		Value: kubernetes.GetMinReplicas(statefulSet.Annotations, 1),
+	}}
+	patchesBytes, _ := json.Marshal(patches)
+	_, err = statefulSetsClient.Patch(
+		ctx,
+		app.name,
 		k8s_types.JSONPatchType,
 		patchesBytes,
 		metav1.PatchOptions{},

--- a/pkg/deployments/activator/app.go
+++ b/pkg/deployments/activator/app.go
@@ -5,10 +5,18 @@ import (
 	"net/url"
 )
 
+type appKind string
+
+const (
+	appKindDeployment  appKind = "Deployment"
+	appKindStatefulSet appKind = "StatefulSet"
+)
+
 type app struct {
 	namespace           string
 	serviceName         string
-	deploymentName      string
+	name                string
+	kind                appKind
 	targetURL           *url.URL
 	proxyRequestHandler *httputil.ReverseProxy
 }

--- a/pkg/deployments/activator/app_activation.go
+++ b/pkg/deployments/activator/app_activation.go
@@ -15,7 +15,7 @@ import (
 	k8s "github.com/dailymotion/osiris/pkg/kubernetes"
 )
 
-type deploymentActivation struct {
+type appActivation struct {
 	readyAppPodIPs map[string]struct{}
 	endpoints      *corev1.Endpoints
 	lock           sync.Mutex
@@ -23,14 +23,14 @@ type deploymentActivation struct {
 	timeoutCh      chan struct{}
 }
 
-func (d *deploymentActivation) watchForCompletion(
+func (a *appActivation) watchForCompletion(
 	kubeClient kubernetes.Interface,
 	app *app,
 	appPodSelector labels.Selector,
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// Watch the pods managed by this deployment
+	// Watch the pods managed by this deployment/statefulSet
 	podsInformer := k8s.PodsIndexInformer(
 		kubeClient,
 		app.namespace,
@@ -38,11 +38,11 @@ func (d *deploymentActivation) watchForCompletion(
 		appPodSelector,
 	)
 	podsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: d.syncPod,
+		AddFunc: a.syncPod,
 		UpdateFunc: func(_, newObj interface{}) {
-			d.syncPod(newObj)
+			a.syncPod(newObj)
 		},
-		DeleteFunc: d.syncPod,
+		DeleteFunc: a.syncPod,
 	})
 	// Watch the corresponding endpoints resource for this service
 	endpointsInformer := k8s.EndpointsIndexInformer(
@@ -55,9 +55,9 @@ func (d *deploymentActivation) watchForCompletion(
 		nil,
 	)
 	endpointsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: d.syncEndpoints,
+		AddFunc: a.syncEndpoints,
 		UpdateFunc: func(_, newObj interface{}) {
-			d.syncEndpoints(newObj)
+			a.syncEndpoints(newObj)
 		},
 	})
 	go podsInformer.Run(ctx.Done())
@@ -66,23 +66,24 @@ func (d *deploymentActivation) watchForCompletion(
 	defer timer.Stop()
 	for {
 		select {
-		case <-d.successCh:
+		case <-a.successCh:
 			return
 		case <-timer.C:
 			glog.Errorf(
-				"Activation of deployment %s in namespace %s timed out",
-				app.deploymentName,
+				"Activation of %s %s in namespace %s timed out",
+				app.kind,
+				app.name,
 				app.namespace,
 			)
-			close(d.timeoutCh)
+			close(a.timeoutCh)
 			return
 		}
 	}
 }
 
-func (d *deploymentActivation) syncPod(obj interface{}) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
+func (a *appActivation) syncPod(obj interface{}) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
 	pod := obj.(*corev1.Pod)
 	var ready bool
 	for _, condition := range pod.Status.Conditions {
@@ -95,27 +96,27 @@ func (d *deploymentActivation) syncPod(obj interface{}) {
 	}
 	// Keep track of which pods are ready
 	if ready {
-		d.readyAppPodIPs[pod.Status.PodIP] = struct{}{}
+		a.readyAppPodIPs[pod.Status.PodIP] = struct{}{}
 	} else {
-		delete(d.readyAppPodIPs, pod.Status.PodIP)
+		delete(a.readyAppPodIPs, pod.Status.PodIP)
 	}
-	d.checkActivationComplete()
+	a.checkActivationComplete()
 }
 
-func (d *deploymentActivation) syncEndpoints(obj interface{}) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
-	d.endpoints = obj.(*corev1.Endpoints)
-	d.checkActivationComplete()
+func (a *appActivation) syncEndpoints(obj interface{}) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	a.endpoints = obj.(*corev1.Endpoints)
+	a.checkActivationComplete()
 }
 
-func (d *deploymentActivation) checkActivationComplete() {
-	if d.endpoints != nil {
-		for _, subset := range d.endpoints.Subsets {
+func (a *appActivation) checkActivationComplete() {
+	if a.endpoints != nil {
+		for _, subset := range a.endpoints.Subsets {
 			for _, address := range subset.Addresses {
-				if _, ok := d.readyAppPodIPs[address.IP]; ok {
+				if _, ok := a.readyAppPodIPs[address.IP]; ok {
 					glog.Infof("App pod with ip %s is in service", address.IP)
-					close(d.successCh)
+					close(a.successCh)
 					return
 				}
 			}

--- a/pkg/deployments/activator/index.go
+++ b/pkg/deployments/activator/index.go
@@ -17,122 +17,138 @@ var (
 
 // updateIndex builds an index that maps all the possible ways a service can be
 // addressed to application info that encapsulates details like which deployment
-// to activate and where to relay requests to after successful activation. The
-// new index replaces any old/existing index.
+// or statefulSet to activate and where to relay requests to after successful
+// activation. The new index replaces any old/existing index.
 func (a *activator) updateIndex() {
 	appsByHost := map[string]*app{}
 	for _, svc := range a.services {
+		var (
+			name string
+			kind appKind
+		)
 		if deploymentName, ok :=
 			svc.Annotations["osiris.dm.gg/deployment"]; ok {
-			svcShortDNSName := fmt.Sprintf("%s.%s", svc.Name, svc.Namespace)
-			svcFullDNSName := fmt.Sprintf("%s.svc.cluster.local", svcShortDNSName)
-			// Determine the "default" ingress port. When a request arrives at the
-			// activator via an ingress conroller, the request's host header won't
-			// indicate a port. After activation is complete, the activator needs to
-			// forward the request to the service (which is now backed by application
-			// endpoints). It's important to know which service port to forward the
-			// request to.
-			var ingressDefaultPort string
-			// Start by seeing if a default port was explicitly specified.
-			if ingressDefaultPort, ok =
-				svc.Annotations["osiris.dm.gg/ingressDefaultPort"]; !ok {
-				// If not specified, try to infer it.
-				// If there's only one port, that's it.
-				if len(svc.Spec.Ports) == 1 {
-					ingressDefaultPort = fmt.Sprintf("%d", svc.Spec.Ports[0].Port)
-				} else {
-					// Look for a port named "http". If found, that's it. While we're
-					// looping also look to see if the servie exposes port 80. If no port
-					// is named "http", we'll assume 80 (if exposed) is the default port.
-					var foundPort80 bool
-					for _, port := range svc.Spec.Ports {
-						if port.Name == "http" {
-							ingressDefaultPort = fmt.Sprintf("%d", port.Port)
-							break
-						}
-						if port.Port == 80 {
-							foundPort80 = true
-						}
+			name = deploymentName
+			kind = appKindDeployment
+		} else if statefulSetName, ok :=
+			svc.Annotations["osiris.dm.gg/statefulset"]; ok {
+			name = statefulSetName
+			kind = appKindStatefulSet
+		}
+		if len(name) == 0 {
+			continue
+		}
+
+		svcShortDNSName := fmt.Sprintf("%s.%s", svc.Name, svc.Namespace)
+		svcFullDNSName := fmt.Sprintf("%s.svc.cluster.local", svcShortDNSName)
+		// Determine the "default" ingress port. When a request arrives at the
+		// activator via an ingress conroller, the request's host header won't
+		// indicate a port. After activation is complete, the activator needs to
+		// forward the request to the service (which is now backed by application
+		// endpoints). It's important to know which service port to forward the
+		// request to.
+		var ingressDefaultPort string
+		var ok bool
+		// Start by seeing if a default port was explicitly specified.
+		if ingressDefaultPort, ok =
+			svc.Annotations["osiris.dm.gg/ingressDefaultPort"]; !ok {
+			// If not specified, try to infer it.
+			// If there's only one port, that's it.
+			if len(svc.Spec.Ports) == 1 {
+				ingressDefaultPort = fmt.Sprintf("%d", svc.Spec.Ports[0].Port)
+			} else {
+				// Look for a port named "http". If found, that's it. While we're
+				// looping also look to see if the servie exposes port 80. If no port
+				// is named "http", we'll assume 80 (if exposed) is the default port.
+				var foundPort80 bool
+				for _, port := range svc.Spec.Ports {
+					if port.Name == "http" {
+						ingressDefaultPort = fmt.Sprintf("%d", port.Port)
+						break
 					}
-					if ingressDefaultPort == "" && foundPort80 {
-						ingressDefaultPort = "80"
+					if port.Port == 80 {
+						foundPort80 = true
 					}
+				}
+				if ingressDefaultPort == "" && foundPort80 {
+					ingressDefaultPort = "80"
 				}
 			}
-			// For every port...
-			for _, port := range svc.Spec.Ports {
-				targetURL, err :=
-					url.Parse(fmt.Sprintf("http://%s:%d", svc.Spec.ClusterIP, port.Port))
-				if err != nil {
-					glog.Errorf(
-						"Error parsing target URL for service %s in namespace %s: %s",
-						svc.Name,
-						svc.Namespace,
-						err,
-					)
-					continue
-				}
-				app := &app{
-					namespace:           svc.Namespace,
-					serviceName:         svc.Name,
-					deploymentName:      deploymentName,
-					targetURL:           targetURL,
-					proxyRequestHandler: httputil.NewSingleHostReverseProxy(targetURL),
-				}
-				// If the port is 80, also index by hostname/IP sans port number...
-				if port.Port == 80 {
-					// kube-dns names
-					appsByHost[svcShortDNSName] = app
-					appsByHost[svcFullDNSName] = app
-					// cluster IP
-					appsByHost[svc.Spec.ClusterIP] = app
-					// external IPs
-					for _, loadBalancerIngress := range svc.Status.LoadBalancer.Ingress {
-						if loadBalancerIngress.IP != "" {
-							appsByHost[loadBalancerIngress.IP] = app
-						}
-					}
-					// Honor all annotations of the form
-					// ^osiris\.dm\.gg/loadBalancerHostname(?:-\d+)?$
-					for k, v := range svc.Annotations {
-						if loadBalancerHostnameAnnotationRegex.MatchString(k) {
-							appsByHost[v] = app
-						}
-					}
-				}
-				if fmt.Sprintf("%d", port.Port) == ingressDefaultPort {
-					// Honor all annotations of the form
-					// ^osiris\.dm\.gg/ingressHostname(?:-\d+)?$
-					for k, v := range svc.Annotations {
-						if ingressHostnameAnnotationRegex.MatchString(k) {
-							appsByHost[v] = app
-						}
-					}
-				}
-				// Now index by hostname/IP:port...
+		}
+		// For every port...
+		for _, port := range svc.Spec.Ports {
+			targetURL, err :=
+				url.Parse(fmt.Sprintf("http://%s:%d", svc.Spec.ClusterIP, port.Port))
+			if err != nil {
+				glog.Errorf(
+					"Error parsing target URL for service %s in namespace %s: %s",
+					svc.Name,
+					svc.Namespace,
+					err,
+				)
+				continue
+			}
+			app := &app{
+				namespace:           svc.Namespace,
+				serviceName:         svc.Name,
+				name:                name,
+				kind:                kind,
+				targetURL:           targetURL,
+				proxyRequestHandler: httputil.NewSingleHostReverseProxy(targetURL),
+			}
+			// If the port is 80, also index by hostname/IP sans port number...
+			if port.Port == 80 {
 				// kube-dns names
-				appsByHost[fmt.Sprintf("%s:%d", svcShortDNSName, port.Port)] = app
-				appsByHost[fmt.Sprintf("%s:%d", svcFullDNSName, port.Port)] = app
+				appsByHost[svcShortDNSName] = app
+				appsByHost[svcFullDNSName] = app
 				// cluster IP
-				appsByHost[fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, port.Port)] = app
+				appsByHost[svc.Spec.ClusterIP] = app
 				// external IPs
 				for _, loadBalancerIngress := range svc.Status.LoadBalancer.Ingress {
 					if loadBalancerIngress.IP != "" {
-						appsByHost[fmt.Sprintf("%s:%d", loadBalancerIngress.IP, port.Port)] = app // nolint: lll
-					}
-				}
-				// Node honame/IP:node-port
-				if port.NodePort != 0 {
-					for nodeAddress := range a.nodeAddresses {
-						appsByHost[fmt.Sprintf("%s:%d", nodeAddress, port.NodePort)] = app
+						appsByHost[loadBalancerIngress.IP] = app
 					}
 				}
 				// Honor all annotations of the form
 				// ^osiris\.dm\.gg/loadBalancerHostname(?:-\d+)?$
 				for k, v := range svc.Annotations {
 					if loadBalancerHostnameAnnotationRegex.MatchString(k) {
-						appsByHost[fmt.Sprintf("%s:%d", v, port.Port)] = app
+						appsByHost[v] = app
 					}
+				}
+			}
+			if fmt.Sprintf("%d", port.Port) == ingressDefaultPort {
+				// Honor all annotations of the form
+				// ^osiris\.dm\.gg/ingressHostname(?:-\d+)?$
+				for k, v := range svc.Annotations {
+					if ingressHostnameAnnotationRegex.MatchString(k) {
+						appsByHost[v] = app
+					}
+				}
+			}
+			// Now index by hostname/IP:port...
+			// kube-dns names
+			appsByHost[fmt.Sprintf("%s:%d", svcShortDNSName, port.Port)] = app
+			appsByHost[fmt.Sprintf("%s:%d", svcFullDNSName, port.Port)] = app
+			// cluster IP
+			appsByHost[fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, port.Port)] = app
+			// external IPs
+			for _, loadBalancerIngress := range svc.Status.LoadBalancer.Ingress {
+				if loadBalancerIngress.IP != "" {
+					appsByHost[fmt.Sprintf("%s:%d", loadBalancerIngress.IP, port.Port)] = app // nolint: lll
+				}
+			}
+			// Node honame/IP:node-port
+			if port.NodePort != 0 {
+				for nodeAddress := range a.nodeAddresses {
+					appsByHost[fmt.Sprintf("%s:%d", nodeAddress, port.NodePort)] = app
+				}
+			}
+			// Honor all annotations of the form
+			// ^osiris\.dm\.gg/loadBalancerHostname(?:-\d+)?$
+			for k, v := range svc.Annotations {
+				if loadBalancerHostnameAnnotationRegex.MatchString(k) {
+					appsByHost[fmt.Sprintf("%s:%d", v, port.Port)] = app
 				}
 			}
 		}

--- a/pkg/deployments/activator/keys.go
+++ b/pkg/deployments/activator/keys.go
@@ -4,6 +4,6 @@ import (
 	"fmt"
 )
 
-func getKey(namespace, name string) string {
-	return fmt.Sprintf("%s:%s", namespace, name)
+func getKey(namespace string, kind appKind, name string) string {
+	return fmt.Sprintf("%s:%s/%s", kind, namespace, name)
 }

--- a/pkg/deployments/zeroscaler/zeroscaler_test.go
+++ b/pkg/deployments/zeroscaler/zeroscaler_test.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	k8s "github.com/dailymotion/osiris/pkg/kubernetes"
@@ -79,7 +77,7 @@ func TestGetMetricsCheckInterval(t *testing.T) {
 	testcases := []struct {
 		name           string
 		zeroScaler     *zeroscaler
-		deployment     *appsv1.Deployment
+		annotations    map[string]string
 		expectedResult time.Duration
 	}{
 		{
@@ -89,11 +87,7 @@ func TestGetMetricsCheckInterval(t *testing.T) {
 					MetricsCheckInterval: 150,
 				},
 			},
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			},
+			annotations:    map[string]string{},
 			expectedResult: 150 * time.Second,
 		},
 		{
@@ -103,12 +97,8 @@ func TestGetMetricsCheckInterval(t *testing.T) {
 					MetricsCheckInterval: 150,
 				},
 			},
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						k8s.MetricsCheckIntervalAnnotationName: "60",
-					},
-				},
+			annotations: map[string]string{
+				k8s.MetricsCheckIntervalAnnotationName: "60",
 			},
 			expectedResult: 60 * time.Second,
 		},
@@ -119,12 +109,8 @@ func TestGetMetricsCheckInterval(t *testing.T) {
 					MetricsCheckInterval: 150,
 				},
 			},
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						k8s.MetricsCheckIntervalAnnotationName: "something",
-					},
-				},
+			annotations: map[string]string{
+				k8s.MetricsCheckIntervalAnnotationName: "something",
 			},
 			expectedResult: 150 * time.Second,
 		},
@@ -135,12 +121,8 @@ func TestGetMetricsCheckInterval(t *testing.T) {
 					MetricsCheckInterval: 150,
 				},
 			},
-			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						k8s.MetricsCheckIntervalAnnotationName: "-60",
-					},
-				},
+			annotations: map[string]string{
+				k8s.MetricsCheckIntervalAnnotationName: "-60",
 			},
 			expectedResult: 150 * time.Second,
 		},
@@ -148,7 +130,7 @@ func TestGetMetricsCheckInterval(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			actual := test.zeroScaler.getMetricsCheckInterval(test.deployment)
+			actual := test.zeroScaler.getMetricsCheckInterval("Deployment", "whatever", test.annotations)
 
 			assert.Equal(t, test.expectedResult, actual)
 		})

--- a/pkg/endpoints/controller/endpoints_manager.go
+++ b/pkg/endpoints/controller/endpoints_manager.go
@@ -98,8 +98,8 @@ func (e *endpointsManager) run(ctx context.Context) {
 		)
 	}()
 	e.podsInformer.Run(ctx.Done())
-	// force an initial sync of the endpoints for deployments that are initially
-	// scaled to 0, and for which we won't see Pod events.
+	// force an initial sync of the endpoints for deployments/statefulsets
+	// that are initially scaled to 0, and for which we won't see Pod events.
 	e.syncEndpoints()
 }
 

--- a/pkg/endpoints/hijacker/hijacker.go
+++ b/pkg/endpoints/hijacker/hijacker.go
@@ -214,10 +214,13 @@ func (h *hijacker) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 func validateService(svc *corev1.Service) error {
 	if kubernetes.ResourceIsOsirisEnabled(svc.Annotations) {
-		if _, ok := svc.Annotations["osiris.dm.gg/deployment"]; !ok {
+		_, deploymentPresent := svc.Annotations["osiris.dm.gg/deployment"]
+		_, statefulSetPresent := svc.Annotations["osiris.dm.gg/statefulset"]
+		if !deploymentPresent && !statefulSetPresent {
 			return fmt.Errorf(
 				`Osiris-enabled service %s in namespace %s is lacking the required `+
-					`"osiris.dm.gg/deployment" annotation`,
+					`"osiris.dm.gg/deployment" or`+
+					`"osiris.dm.gg/statefulset" annotation`,
 				svc.Name,
 				svc.Namespace,
 			)

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -48,6 +48,40 @@ func DeploymentsIndexInformer(
 	)
 }
 
+func StatefulSetsIndexInformer(
+	client kubernetes.Interface,
+	namespace string,
+	fieldSelector fields.Selector,
+	labelSelector labels.Selector,
+) cache.SharedIndexInformer {
+	statefulSetsClient := client.AppsV1().StatefulSets(namespace)
+	return cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				if fieldSelector != nil {
+					options.FieldSelector = fieldSelector.String()
+				}
+				if labelSelector != nil {
+					options.LabelSelector = labelSelector.String()
+				}
+				return statefulSetsClient.List(context.TODO(), options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				if fieldSelector != nil {
+					options.FieldSelector = fieldSelector.String()
+				}
+				if labelSelector != nil {
+					options.LabelSelector = labelSelector.String()
+				}
+				return statefulSetsClient.Watch(context.TODO(), options)
+			},
+		},
+		&appsv1.StatefulSet{},
+		0,
+		cache.Indexers{},
+	)
+}
+
 func PodsIndexInformer(
 	client kubernetes.Interface,
 	namespace string,


### PR DESCRIPTION
apply https://github.com/deislabs/osiris/pull/43

With this change, Osiris can now manage both Deployments and StatefulSets.

I introduced a new service annotation `osiris.deislabs.io/statefulset` to link a service with its statefulset, otherwise everything works the same as with Deployments.

Internally, I tried to avoid duplicated code, and introduced a `kind` parameter to make a distinction between deployments and statefulsets.