### PR TITLE
Rename annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ metadata:
   namespace: my-aoo
   name: my-app
   annotations:
-    osiris.dm.gg/enabled: "true"
+    osiris.dm.gg/enableScaling: "true"
 spec:
   replicas: 1
   selector:
@@ -163,7 +163,7 @@ metadata:
   namespace: my-namespace
   name: my-app
   annotations:
-    osiris.dm.gg/enabled: "true"
+    osiris.dm.gg/manageEndpoints: "true"
     osiris.dm.gg/deployment: my-app
 spec:
   selector:
@@ -181,7 +181,7 @@ The following table lists the supported annotations for Kubernetes `Deployments`
 
 | Annotation | Description | Default |
 | ---------- | ----------- | ------- |
-| `osiris.dm.gg/enabled` | Enable the zeroscaler component to scrape and analyze metrics from the deployment's or statefulSet's pods and scale the deployment/statefulSet to zero when idle. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
+| `osiris.dm.gg/enableScaling` | Enable the zeroscaler component to scrape and analyze metrics from the deployment's or statefulSet's pods and scale the deployment/statefulSet to zero when idle. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
 | `osiris.dm.gg/minReplicas` | The minimum number of replicas to set on the deployment/statefulSet when Osiris will scale up. If you set `2`, Osiris will scale the deployment/statefulSet from `0` to `2` replicas directly. Osiris won't collect metrics from deployments/statefulSets which have more than `minReplicas` replicas - to avoid useless collections of metrics. | `1` |
 | `osiris.dm.gg/metricsCheckInterval` | The interval in which Osiris would repeatedly track the pod http request metrics. The value is the number of seconds of the interval. Note that this value override the global value defined by the `zeroscaler.metricsCheckInterval` Helm value. | _value of the `zeroscaler.metricsCheckInterval` Helm value_ |
 | `osiris.dm.gg/metricsCollector` | Configure the collection of metrics for a pod. The value is a JSON object with at least a `type` string, and an optional `implementation` object. See the *Metrics Scraping* section for more. | `{ "type": "osiris" }` |
@@ -201,7 +201,7 @@ The following table lists the supported annotations for Kubernetes `Services` an
 
 | Annotation | Description | Default |
 | ---------- | ----------- | ------- |
-| `osiris.dm.gg/enabled` | Enable this service's endpoints to be managed by the Osiris endpoints controller. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
+| `osiris.dm.gg/manageEndpoints` | Enable this service's endpoints to be managed by the Osiris endpoints controller. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
 | `osiris.dm.gg/deployment` | Name of the deployment which is behind this service. This is _required_ to map the service with its deployment. | _no value_ |
 | `osiris.dm.gg/statefulset` | Name of the statefulSet which is behind this service. This is _required_ to map the service with its statefulSet. | _no value_ |
 | `osiris.dm.gg/loadBalancerHostname` | Map requests coming from a specific hostname to this service. Note that if you have multiple hostnames, you can set them with different annotations, using `osiris.dm.gg/loadBalancerHostname-1`, `osiris.dm.gg/loadBalancerHostname-2`, ... | _no value_ |

--- a/example/hello-osiris.yaml
+++ b/example/hello-osiris.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: hello-osiris
   annotations:
-    osiris.dm.gg/enabled: "true"
+    osiris.dm.gg/manageEndpoints: "true"
     osiris.dm.gg/deployment: hello-osiris
     osiris.dm.gg/loadBalancerHostname: hello-osiris.contoso.io
 spec:
@@ -27,7 +27,7 @@ metadata:
   labels:
     app: hello-osiris
   annotations:
-    osiris.dm.gg/enabled: "true"
+    osiris.dm.gg/enableScaling: "true"
     osiris.dm.gg/minReplicas: "1"
     osiris.dm.gg/metricsCheckInterval: "120" # seconds
 spec:

--- a/pkg/deployments/activator/activator.go
+++ b/pkg/deployments/activator/activator.go
@@ -107,7 +107,7 @@ func (a *activator) syncService(obj interface{}) {
 	defer a.indicesLock.Unlock()
 	svc := obj.(*corev1.Service)
 	svcKey := getKey(svc.Namespace, "Service", svc.Name)
-	if k8s.ResourceIsOsirisEnabled(svc.Annotations) {
+	if k8s.ServiceIsEligibleForEndpointsManagement(svc.Annotations) {
 		a.services[svcKey] = svc
 	} else {
 		delete(a.services, svcKey)

--- a/pkg/deployments/zeroscaler/zeroscaler.go
+++ b/pkg/deployments/zeroscaler/zeroscaler.go
@@ -93,7 +93,7 @@ func (z *zeroscaler) Run(ctx context.Context) {
 
 func (z *zeroscaler) syncDeployment(obj interface{}) {
 	deployment := obj.(*appsv1.Deployment)
-	if k8s.ResourceIsOsirisEnabled(deployment.Annotations) {
+	if k8s.WorkloadIsEligibleForAutoScaling(deployment.Annotations) {
 		glog.Infof(
 			"Notified about new or updated Osiris-enabled deployment %s in "+
 				"namespace %s",
@@ -147,7 +147,7 @@ func (z *zeroscaler) syncDeployment(obj interface{}) {
 
 func (z *zeroscaler) syncStatefulSet(obj interface{}) {
 	statefulSet := obj.(*appsv1.StatefulSet)
-	if k8s.ResourceIsOsirisEnabled(statefulSet.Annotations) {
+	if k8s.WorkloadIsEligibleForAutoScaling(statefulSet.Annotations) {
 		glog.Infof(
 			"Notified about new or updated Osiris-enabled statefulSet %s in "+
 				"namespace %s",

--- a/pkg/endpoints/controller/controller.go
+++ b/pkg/endpoints/controller/controller.go
@@ -117,7 +117,7 @@ func (c *controller) Run(ctx context.Context) {
 // be prevented for non-Osiris-enabled services.
 func (c *controller) syncAppService(obj interface{}) {
 	svc := obj.(*corev1.Service)
-	if k8s.ResourceIsOsirisEnabled(svc.Annotations) {
+	if k8s.ServiceIsEligibleForEndpointsManagement(svc.Annotations) {
 		glog.Infof(
 			"Notified about new or updated Osiris-enabled service %s in namespace %s",
 			svc.Name,

--- a/pkg/endpoints/hijacker/hijacker.go
+++ b/pkg/endpoints/hijacker/hijacker.go
@@ -213,7 +213,7 @@ func (h *hijacker) handleRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 func validateService(svc *corev1.Service) error {
-	if kubernetes.ResourceIsOsirisEnabled(svc.Annotations) {
+	if kubernetes.ServiceIsEligibleForEndpointsManagement(svc.Annotations) {
 		_, deploymentPresent := svc.Annotations["osiris.dm.gg/deployment"]
 		_, statefulSetPresent := svc.Annotations["osiris.dm.gg/statefulset"]
 		if !deploymentPresent && !statefulSetPresent {

--- a/pkg/endpoints/hijacker/service_patch.go
+++ b/pkg/endpoints/hijacker/service_patch.go
@@ -27,7 +27,7 @@ func getServicePatchOperations(
 	patchOps := []kubernetes.PatchOperation{}
 
 	// Service is Osiris-enabled... make it so...
-	if kubernetes.ResourceIsOsirisEnabled(svc.Annotations) {
+	if kubernetes.ServiceIsEligibleForEndpointsManagement(svc.Annotations) {
 
 		glog.Infof("Hijacking service %s", svc.Name)
 

--- a/pkg/kubernetes/osiris.go
+++ b/pkg/kubernetes/osiris.go
@@ -9,20 +9,27 @@ const (
 	IgnoredPathsAnnotationName         = "osiris.dm.gg/ignoredPaths"
 	MetricsCollectorAnnotationName     = "osiris.dm.gg/metricsCollector"
 	MetricsCheckIntervalAnnotationName = "osiris.dm.gg/metricsCheckInterval"
-	osirisEnabledAnnotationName        = "osiris.dm.gg/enabled"
+	enableScalingAnnotationName        = "osiris.dm.gg/enableScaling"
 	collectMetricsAnnotationName       = "osiris.dm.gg/collectMetrics"
+	manageEndpointsAnnotationName      = "osiris.dm.gg/manageEndpoints"
 )
 
-// ResourceIsOsirisEnabled checks the annotations to see if the
-// kube resource is enabled for osiris or not.
-func ResourceIsOsirisEnabled(annotations map[string]string) bool {
-	return annotationBooleanValue(annotations, osirisEnabledAnnotationName)
+// WorkloadIsEligibleForAutoScaling checks the annotations to see if the
+// workload (deployment or statefulset) is eligible for auto-scaling with osiris or not.
+func WorkloadIsEligibleForAutoScaling(annotations map[string]string) bool {
+	return annotationBooleanValue(annotations, enableScalingAnnotationName)
 }
 
 // PodIsEligibleForProxyInjection checks the annotations to see if the
 // pod is eligible for proxy injection or not.
 func PodIsEligibleForProxyInjection(annotations map[string]string) bool {
 	return annotationBooleanValue(annotations, collectMetricsAnnotationName)
+}
+
+// ServiceIsEligibleForEndpointsManagement checks the annotations to see if the
+// service is eligible for management of its endpoints by osiris or not.
+func ServiceIsEligibleForEndpointsManagement(annotations map[string]string) bool {
+	return annotationBooleanValue(annotations, manageEndpointsAnnotationName)
 }
 
 func annotationBooleanValue(annotations map[string]string, key string) bool {

--- a/pkg/kubernetes/osiris_test.go
+++ b/pkg/kubernetes/osiris_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestResourceIsOsirisEnabled(t *testing.T) {
+func TestAnnotationBooleanValue(t *testing.T) {
 	testcases := []struct {
 		name           string
 		annotations    map[string]string
@@ -13,35 +13,35 @@ func TestResourceIsOsirisEnabled(t *testing.T) {
 		{
 			name: "map with osiris enabled entry and value 1",
 			annotations: map[string]string{
-				osirisEnabledAnnotationName: "1",
+				enableScalingAnnotationName: "1",
 			},
 			expectedResult: true,
 		},
 		{
 			name: "map with osiris enabled entry and value true",
 			annotations: map[string]string{
-				osirisEnabledAnnotationName: "true",
+				enableScalingAnnotationName: "true",
 			},
 			expectedResult: true,
 		},
 		{
 			name: "map with osiris enabled entry and value on",
 			annotations: map[string]string{
-				osirisEnabledAnnotationName: "on",
+				enableScalingAnnotationName: "on",
 			},
 			expectedResult: true,
 		},
 		{
 			name: "map with osiris enabled entry and value y",
 			annotations: map[string]string{
-				osirisEnabledAnnotationName: "y",
+				enableScalingAnnotationName: "y",
 			},
 			expectedResult: true,
 		},
 		{
 			name: "map with osiris enabled entry and value yes",
 			annotations: map[string]string{
-				osirisEnabledAnnotationName: "yes",
+				enableScalingAnnotationName: "yes",
 			},
 			expectedResult: true,
 		},
@@ -54,7 +54,7 @@ func TestResourceIsOsirisEnabled(t *testing.T) {
 		{
 			name: "map with osiris enabled entry and invalid value",
 			annotations: map[string]string{
-				osirisEnabledAnnotationName: "yee",
+				enableScalingAnnotationName: "yee",
 			},
 			expectedResult: false,
 		},
@@ -62,10 +62,10 @@ func TestResourceIsOsirisEnabled(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			actual := ResourceIsOsirisEnabled(test.annotations)
+			actual := annotationBooleanValue(test.annotations, enableScalingAnnotationName)
 			if actual != test.expectedResult {
 				t.Errorf(
-					"expected ResourceIsOsirisEnabled to return %t, but got %t",
+					"expected annotationBooleanValue to return %t, but got %t",
 					test.expectedResult, actual)
 			}
 		})


### PR DESCRIPTION
see https://github.com/deislabs/osiris/pull/49#issuecomment-546954464

no more `osiris.xxx/enabled` annotation, it's been replaced by:
- `osiris.xxx/collectMetrics` for the pods
- `osiris.xxx/enableScaling` for the workloads (deployments/statefulsets)
- `osiris.xxx/manageEndpoints` for the services