### PR TITLE
switch to GHCR to host our container images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.2.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,11 +21,11 @@ dockers:
     extra_files:
       - bin/
     image_templates:
-      - "docker.pkg.github.com/dailymotion/osiris/{{.ProjectName}}:{{ .Version }}"
-      - "docker.pkg.github.com/dailymotion/osiris/{{.ProjectName}}:{{ .Tag }}"
-      - "docker.pkg.github.com/dailymotion/osiris/{{.ProjectName}}:v{{ .Major }}"
-      - "docker.pkg.github.com/dailymotion/osiris/{{.ProjectName}}:v{{ .Major }}.{{ .Minor }}"
-      - "docker.pkg.github.com/dailymotion/osiris/{{.ProjectName}}:latest"
+      - "ghcr.io/dailymotion/{{.ProjectName}}:{{ .Version }}"
+      - "ghcr.io/dailymotion/{{.ProjectName}}:{{ .Tag }}"
+      - "ghcr.io/dailymotion/{{.ProjectName}}:v{{ .Major }}"
+      - "ghcr.io/dailymotion/{{.ProjectName}}:v{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/dailymotion/{{.ProjectName}}:latest"
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"

--- a/charts/osiris/values.yaml
+++ b/charts/osiris/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ""
 
 image:
   ## Image location, NOT including the tag
-  repository: docker.pkg.github.com/dailymotion/osiris/osiris
+  repository: ghcr.io/dailymotion/osiris
   ## Image tag. Optional, default to the chart's AppVersion
   tag:
   ## Image pull policy


### PR DESCRIPTION
because github packages requires a github auth to download public images