### PR TITLE
fix: can't use a svc DNS name without a namespace

### DIFF
--- a/pkg/deployments/activator/index.go
+++ b/pkg/deployments/activator/index.go
@@ -41,7 +41,6 @@ func (a *activator) updateIndex() {
 		}
 
 		svcDNSNames := []string{
-			fmt.Sprintf("%s", svc.Name),
 			fmt.Sprintf("%s.%s", svc.Name, svc.Namespace),
 			fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace),
 			fmt.Sprintf("%s.%s.svc.cluster", svc.Name, svc.Namespace),


### PR DESCRIPTION
otherwise we'll have a collision if multiple namespaces have a svc with the same name